### PR TITLE
Yash edit command

### DIFF
--- a/PDPAssignment4/src/controller/command/CommandFactory.java
+++ b/PDPAssignment4/src/controller/command/CommandFactory.java
@@ -30,7 +30,7 @@ public class CommandFactory {
     registerCommand(new PrintEventsCommand(calendar));
     registerCommand(new ShowStatusCommand(calendar));
     registerCommand(new ExportCalendarCommand(calendar));
-    //registerCommand(new EditEventCommand(calendar));
+    registerCommand(new EditEventCommand(calendar));
     registerCommand(new ExitCommand());
 
     this.calendar = calendar;


### PR DESCRIPTION
## Edit Command Parsing Implementation

This PR adds comprehensive parsing functionality for edit commands to the CommandParser class. The implementation includes:

* Three distinct regex patterns to match different edit command formats:
  * `edit event [property] [subject] from [startDateTime] to [endDateTime] with [newValue]`
  * `edit events [property] [subject] from [startDateTime] with [newValue]`
  * `edit events [property] [subject] [newValue]`
* Proper argument extraction and validation for each command type
* Integration with the EditEventCommand implementation
* Handling for different event editing scenarios (single event, events from date, all events)
* Error handling for invalid command formats

These changes complete the command parsing requirements for the event editing functionality as specified in the assignment.