### PR TITLE
feat(controller): Implement ShowStatusCommand execution logic

### DIFF
--- a/PDPAssignment4/src/controller/command/ShowStatusCommand.java
+++ b/PDPAssignment4/src/controller/command/ShowStatusCommand.java
@@ -4,18 +4,15 @@ import model.calendar.ICalendar;
 import utilities.DateTimeUtil;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
-/**
- * Command for checking the user's status (busy or available) at a specific time.
- */
 public class ShowStatusCommand implements ICommand {
-
   private final ICalendar calendar;
 
   /**
-   * Constructs a new ShowStatusCommand.
+   * Creates a ShowStatusCommand with the given calendar.
    *
-   * @param calendar the calendar model
+   * @param calendar the calendar to query
    */
   public ShowStatusCommand(ICalendar calendar) {
     this.calendar = calendar;
@@ -23,18 +20,21 @@ public class ShowStatusCommand implements ICommand {
 
   @Override
   public String execute(String[] args) {
-    if (args.length < 3 || !args[0].equals("status") || !args[1].equals("on")) {
-      return "Error: Invalid show status command format";
+    if (args.length < 1) {
+      return "Error: Missing date/time for status command";
     }
 
+    LocalDateTime dateTime;
     try {
-      LocalDateTime dateTime = DateTimeUtil.parseDateTime(args[2]);
-      boolean isBusy = calendar.isBusy(dateTime);
-
-      return isBusy ? "busy" : "available";
-    } catch (IllegalArgumentException e) {
-      return "Error: " + e.getMessage();
+      dateTime = DateTimeUtil.parseDateTime(args[0]);
+    } catch (Exception e) {
+      return "Error parsing date/time: " + e.getMessage();
     }
+
+    boolean isBusy = calendar.isBusy(dateTime);
+
+    return "Status on " + dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) +
+            ": " + (isBusy ? "Busy" : "Available");
   }
 
   @Override


### PR DESCRIPTION
Add the execute method to handle the "show status" command functionality:
- Parse the provided date/time string into a LocalDateTime object
- Add proper error handling for invalid date/time formats
- Call the calendar model's isBusy method to check availability
- Format and return a user-friendly response with the status (Busy/Available)
<img width="864" alt="Screenshot 2025-03-07 at 4 15 32 PM" src="https://github.com/user-attachments/assets/bdb80fd2-17c2-44a3-9e58-94574291fa03" />
<img width="847" alt="Screenshot 2025-03-07 at 4 16 13 PM" src="https://github.com/user-attachments/assets/26f82608-6f7f-4917-b592-213a12304659" />
<img width="898" alt="Screenshot 2025-03-07 at 4 16 56 PM" src="https://github.com/user-attachments/assets/fdc44f6c-1b30-4fac-a667-35002f984bbc" />
<img width="1092" alt="Screenshot 2025-03-07 at 4 17 16 PM" src="https://github.com/user-attachments/assets/160c0e83-e49b-4db7-85ad-df0b99705aff" />
