### PR TITLE
Yash print command

### DIFF
--- a/PDPAssignment4/src/controller/command/CreateEventCommand.java
+++ b/PDPAssignment4/src/controller/command/CreateEventCommand.java
@@ -1,12 +1,13 @@
 package controller.command;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+
 import model.calendar.ICalendar;
 import model.event.Event;
 import model.event.RecurringEvent;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import utilities.DateTimeUtil;
-import java.util.Set;
 
 /**
  * Command for creating calendar events (both single and recurring events).
@@ -204,6 +205,16 @@ public class CreateEventCommand implements ICommand {
     }
   }
 
+  /**
+   * Executes the create event command with the provided arguments.
+   * Handles different types of event creation including single events, recurring events,
+   * all-day events, and their variants.
+   *
+   * @param args an array of arguments for the command:
+   *             - args[0]: the type of event to create (single, recurring, allday, etc.)
+   *             - remaining args: parameters specific to each event type
+   * @return a string message indicating the result of the command execution
+   */
   @Override
   public String execute(String[] args) {
     // This method would parse command line arguments and call the appropriate creation method
@@ -261,13 +272,82 @@ public class CreateEventCommand implements ICommand {
           return "Error parsing arguments: " + e.getMessage();
         }
 
+      case "recurring-until":
+        if (args.length < 7) {
+          return "Error: Insufficient arguments for recurring event until date";
+        }
+        try {
+          String name = args[1];
+          LocalDateTime start = DateTimeUtil.parseDateTime(args[2]);
+          LocalDateTime end = DateTimeUtil.parseDateTime(args[3]);
+          String weekdays = args[4];
+          LocalDate untilDate = DateTimeUtil.parseDate(args[5]);
+          boolean autoDecline = Boolean.parseBoolean(args[6]);
+
+          boolean success = calendar.createRecurringEventUntil(name, start, end, weekdays, untilDate, autoDecline);
+
+          if (success) {
+            return "Recurring event '" + name + "' created successfully until " + untilDate + ".";
+          } else {
+            return "Failed to create recurring event due to conflicts.";
+          }
+        } catch (Exception e) {
+          return "Error creating recurring event: " + e.getMessage();
+        }
+
+      case "allday-recurring":
+        if (args.length < 6) {
+          return "Error: Insufficient arguments for all-day recurring event";
+        }
+        try {
+          String name = args[1];
+          LocalDate date = DateTimeUtil.parseDate(args[2]);
+          String weekdays = args[3];
+          int occurrences = Integer.parseInt(args[4]);
+          boolean autoDecline = Boolean.parseBoolean(args[5]);
+
+          boolean success = calendar.createAllDayRecurringEvent(name, date, weekdays, occurrences, autoDecline);
+
+          if (success) {
+            return "All-day recurring event '" + name + "' created successfully with " + occurrences + " occurrences.";
+          } else {
+            return "Failed to create all-day recurring event due to conflicts.";
+          }
+        } catch (Exception e) {
+          return "Error creating all-day recurring event: " + e.getMessage();
+        }
+
+      case "allday-recurring-until":
+        if (args.length < 6) {
+          return "Error: Insufficient arguments for all-day recurring event until date";
+        }
+        try {
+          String name = args[1];
+          LocalDate date = DateTimeUtil.parseDate(args[2]);
+          String weekdays = args[3];
+          LocalDate untilDate = DateTimeUtil.parseDate(args[4]);
+          boolean autoDecline = Boolean.parseBoolean(args[5]);
+
+          boolean success = calendar.createAllDayRecurringEventUntil(name, date, weekdays, untilDate, autoDecline);
+
+          if (success) {
+            return "All-day recurring event '" + name + "' created successfully until " + untilDate + ".";
+          } else {
+            return "Failed to create all-day recurring event due to conflicts.";
+          }
+        } catch (Exception e) {
+          return "Error creating all-day recurring event: " + e.getMessage();
+        }
+
       default:
         return "Error: Unknown create event type: " + args[0];
     }
   }
 
   /**
-   * @return
+   * Returns the name of this command.
+   *
+   * @return the string "create" which identifies this command to the command factory
    */
   @Override
   public String getName() {

--- a/PDPAssignment4/src/controller/command/PrintEventsCommand.java
+++ b/PDPAssignment4/src/controller/command/PrintEventsCommand.java
@@ -2,22 +2,23 @@ package controller.command;
 
 import model.calendar.ICalendar;
 import model.event.Event;
+import utilities.CSVExporter;
 import utilities.DateTimeUtil;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 /**
  * Command for printing events on a specific date or within a date range.
  */
 public class PrintEventsCommand implements ICommand {
-
   private final ICalendar calendar;
 
   /**
-   * Constructs a new PrintEventsCommand.
+   * Creates a PrintEventsCommand with the given calendar.
    *
-   * @param calendar the calendar model
+   * @param calendar the calendar to query
    */
   public PrintEventsCommand(ICalendar calendar) {
     this.calendar = calendar;
@@ -26,120 +27,71 @@ public class PrintEventsCommand implements ICommand {
   @Override
   public String execute(String[] args) {
     if (args.length < 2) {
-      return "Error: Insufficient arguments for print events command";
+      return "Error: Insufficient arguments for print command";
     }
 
-    try {
-      if (args[0].equals("on") && args.length == 2) {
-        // Print events on a specific date
-        LocalDate date = DateTimeUtil.parseDate(args[1]);
-        return printEventsOnDate(date);
-      } else if (args[0].equals("from") && args.length == 4 && args[2].equals("to")) {
-        // Print events within a date range
-        LocalDate startDate = DateTimeUtil.parseDate(args[1]);
-        LocalDate endDate = DateTimeUtil.parseDate(args[3]);
-        return printEventsInRange(startDate, endDate);
-      } else {
-        return "Error: Invalid print events command format";
+    String type = args[0];
+
+    if (type.equals("on_date")) {
+      if (args.length < 2) {
+        return "Error: Missing date for 'print events on' command";
       }
-    } catch (IllegalArgumentException e) {
-      return "Error: " + e.getMessage();
+
+      LocalDate date;
+      try {
+        date = DateTimeUtil.parseDate(args[1]);
+      } catch (Exception e) {
+        return "Error parsing date: " + e.getMessage();
+      }
+
+      return printEventsOnDate(date);
+
+    } else if (type.equals("date_range")) {
+      if (args.length < 3) {
+        return "Error: Missing dates for 'print events from...to' command";
+      }
+
+      LocalDate startDate, endDate;
+      try {
+        startDate = DateTimeUtil.parseDate(args[1]);
+        endDate = DateTimeUtil.parseDate(args[2]);
+      } catch (Exception e) {
+        return "Error parsing dates: " + e.getMessage();
+      }
+
+      return printEventsInRange(startDate, endDate);
+
+    } else {
+      return "Unknown print command type: " + type;
     }
   }
 
-  /**
-   * Prints events on a specific date.
-   *
-   * @param date the date to query
-   * @return a formatted string with the events
-   */
   private String printEventsOnDate(LocalDate date) {
     List<Event> events = calendar.getEventsOnDate(date);
 
     if (events.isEmpty()) {
-      return "No events scheduled for " + DateTimeUtil.formatDate(date);
+      return "No events on " + date.format(DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
     StringBuilder result = new StringBuilder();
-    result.append("Events on ").append(DateTimeUtil.formatDate(date)).append(":\n");
-
-    for (Event event : events) {
-      result.append("• ").append(event.getSubject());
-
-      if (!event.isAllDay()) {
-        result.append(", from ")
-                .append(DateTimeUtil.formatTime(event.getStartDateTime().toLocalTime()))
-                .append(" to ")
-                .append(DateTimeUtil.formatTime(event.getEndDateTime().toLocalTime()));
-      } else {
-        result.append(" (All day)");
-      }
-
-      if (event.getLocation() != null && !event.getLocation().isEmpty()) {
-        result.append(", Location: ").append(event.getLocation());
-      }
-
-      result.append("\n");
-    }
+    result.append("Events on ").append(date.format(DateTimeFormatter.ISO_LOCAL_DATE)).append(":\n");
+    result.append(CSVExporter.formatEventsForDisplay(events, true));
 
     return result.toString();
   }
 
-  /**
-   * Prints events within a date range.
-   *
-   * @param startDate the start date of the range
-   * @param endDate   the end date of the range
-   * @return a formatted string with the events
-   */
   private String printEventsInRange(LocalDate startDate, LocalDate endDate) {
-    if (endDate.isBefore(startDate)) {
-      return "Error: End date cannot be before start date";
-    }
-
     List<Event> events = calendar.getEventsInRange(startDate, endDate);
 
     if (events.isEmpty()) {
-      return "No events scheduled between " + DateTimeUtil.formatDate(startDate) +
-              " and " + DateTimeUtil.formatDate(endDate);
+      return "No events from " + startDate.format(DateTimeFormatter.ISO_LOCAL_DATE) +
+              " to " + endDate.format(DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
     StringBuilder result = new StringBuilder();
-    result.append("Events from ")
-            .append(DateTimeUtil.formatDate(startDate))
-            .append(" to ")
-            .append(DateTimeUtil.formatDate(endDate))
-            .append(":\n");
-
-    // Group events by date
-    LocalDate currentDate = null;
-
-    for (Event event : events) {
-      LocalDate eventDate = event.getStartDateTime().toLocalDate();
-
-      // If we've moved to a new date, print the date header
-      if (currentDate == null || !currentDate.equals(eventDate)) {
-        result.append("\n").append(DateTimeUtil.formatDate(eventDate)).append(":\n");
-        currentDate = eventDate;
-      }
-
-      result.append("• ").append(event.getSubject());
-
-      if (!event.isAllDay()) {
-        result.append(", from ")
-                .append(DateTimeUtil.formatTime(event.getStartDateTime().toLocalTime()))
-                .append(" to ")
-                .append(DateTimeUtil.formatTime(event.getEndDateTime().toLocalTime()));
-      } else {
-        result.append(" (All day)");
-      }
-
-      if (event.getLocation() != null && !event.getLocation().isEmpty()) {
-        result.append(", Location: ").append(event.getLocation());
-      }
-
-      result.append("\n");
-    }
+    result.append("Events from ").append(startDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
+            .append(" to ").append(endDate.format(DateTimeFormatter.ISO_LOCAL_DATE)).append(":\n");
+    result.append(CSVExporter.formatEventsForDisplay(events, false));
 
     return result.toString();
   }


### PR DESCRIPTION
Add functionality to display calendar events in different formats:
- Support both single date and date range printing commands
- Implement date parsing with proper error handling for user input
- Create helper methods printEventsOnDate() and printEventsInRange() to handle
  specific display formats
- Integrate with the CSVExporter to format events consistently
- Add clear messaging for different scenarios including empty results

Extend CreateEventCommand with handlers for all recurring event types:
- Add "recurring-until" case to create recurring events that repeat until a specific date
- Implement "allday-recurring" case to handle all-day events that repeat for a specific
  number of occurrences
- Add "allday-recurring-until" case for all-day events that repeat until a target date

Each case includes:
- Proper argument validation
- Comprehensive error handling with descriptive messages
- Date/time parsing through DateTimeUtil
- Integration with the calendar model's recurring event creation methods
- Success/failure feedback based on conflict resolution outcome